### PR TITLE
Resource leak fix

### DIFF
--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonStringDecoder.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonStringDecoder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.groovy.json.internal;
 
+import java.io.IOException;
+
 public class JsonStringDecoder {
 
     public static String decode(char[] chars, int start, int to) {

--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonStringDecoder.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonStringDecoder.java
@@ -32,5 +32,6 @@ public class JsonStringDecoder {
             builder.decodeJsonString(chars, start, to);
             return builder.toString();    
         }
+        catch(IOException e) { return null; }
     }
 }

--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonStringDecoder.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonStringDecoder.java
@@ -28,8 +28,9 @@ public class JsonStringDecoder {
     }
 
     public static String decodeForSure(char[] chars, int start, int to) {
-        CharBuf builder = CharBuf.create(to - start);
-        builder.decodeJsonString(chars, start, to);
-        return builder.toString();
+        try (CharBuf builder = CharBuf.create(to - start)) {
+            builder.decodeJsonString(chars, start, to);
+            return builder.toString();    
+        }
     }
 }


### PR DESCRIPTION
Fix a resource leak warning.  While CharBuf.close is currently a no-op, CharBuf does inherit from Writer, which has the contract that it should be closed after use.  This change protects against the case where CharBuf may change in the future to use resources that need to be freed.